### PR TITLE
fix(liushen): 友链页字段对齐 Gridea Pro 真实运行时

### DIFF
--- a/themes/liushen/templates/links.html
+++ b/themes/liushen/templates/links.html
@@ -11,25 +11,38 @@
 {% endblock %}
 
 {% block content %}
+{# 友链来源双兼容：
+   - 真实运行时：customConfig.links (即 theme_config.links)，字段 siteName/siteLink/description/avatar
+   - render_test mock：顶层 links 变量，字段 name/url/description/avatar #}
+{% set _links = theme_config.links %}
+{% if not _links %}{% set _links = links %}{% endif %}
+
 <section class="links-page">
   <div class="card-widget">
-    <div class="item-headline"><i class="fa-solid fa-link"></i><span>友情链接</span></div>
+    <div class="item-headline"><i class="fa-solid fa-link"></i><span>友情链接{% if _links %} · {{ _links|length }} 个{% endif %}</span></div>
     <div class="flink-list">
-      {% if links and links|length > 0 %}
-        {% for link in links %}
-          {% set _href = "" %}
-          {% if link.url %}{% set _href = link.url %}{% else %}{% set _href = link.link %}{% endif %}
-          {% set _avatar = "/media/images/default-avatar.svg" %}
-          {% if link.avatar %}{% set _avatar = link.avatar %}{% elif link.icon %}{% set _avatar = link.icon %}{% endif %}
-          {% set _name = "" %}
-          {% if link.name %}{% set _name = link.name %}{% else %}{% set _name = link.title %}{% endif %}
-          {% set _desc = "" %}
-          {% if link.desc %}{% set _desc = link.desc %}{% else %}{% set _desc = link.description %}{% endif %}
+      {% if _links and _links|length > 0 %}
+        {% for link in _links %}
+          {# 名称：siteName → name → title #}
+          {% set _name = link.siteName %}
+          {% if not _name %}{% set _name = link.name %}{% endif %}
+          {% if not _name %}{% set _name = link.title %}{% endif %}
+          {# 链接：siteLink → url → link #}
+          {% set _href = link.siteLink %}
+          {% if not _href %}{% set _href = link.url %}{% endif %}
+          {% if not _href %}{% set _href = link.link %}{% endif %}
+          {# 描述：description → desc #}
+          {% set _desc = link.description %}
+          {% if not _desc %}{% set _desc = link.desc %}{% endif %}
+          {# 头像：avatar → icon → 默认 #}
+          {% set _avatar = link.avatar %}
+          {% if not _avatar %}{% set _avatar = link.icon %}{% endif %}
+          {% if not _avatar %}{% set _avatar = "/media/images/default-avatar.svg" %}{% endif %}
         <a class="flink-item" href="{{ _href }}" target="_blank" rel="noopener">
           <img class="flink-avatar" src="{{ _avatar }}" alt="{{ _name }}" onerror="this.onerror=null;this.src='/media/images/default-avatar.svg';">
           <div class="flink-meta">
             <h4 class="flink-name">{{ _name }}</h4>
-            <p class="flink-desc">{{ _desc }}</p>
+            {% if _desc %}<p class="flink-desc">{{ _desc }}</p>{% endif %}
           </div>
         </a>
         {% endfor %}


### PR DESCRIPTION
## 问题

合并 #8 后，柳神主题的友链页面在实际客户端只显示「描述」，**站点名称完全消失**。

## 根因

Gridea Pro 真实运行时和 mock 数据的友链对象**结构不一致**：

| 维度 | 真实客户端 | render_test mock |
|---|---|---|
| 数据来源 | `customConfig.links`（即 `theme_config.links`） | 顶层 `links` |
| 名称字段 | `siteName` | `name` |
| 链接字段 | `siteLink` | `url` |
| 描述字段 | `description` | `description` |
| 头像字段 | `avatar` | `avatar` |

来源参考：`backend/internal/engine/data_builder.go` 第 238–239 行 —— Gridea Pro 把 \`link.Name\` 注入为 \`siteName\`、\`link.Url\` 注入为 \`siteLink\`。

之前模板只读 \`link.name\` / \`link.title\`，所以客户端真实运行时读到空，名字消失。但因为 mock 数据用的是 \`name\`，render_test 测不出来。

## 修复

\`templates/links.html\` 做**双兼容**：

- 数据源：先 \`theme_config.links\`，回退到 \`links\`
- 名称：\`siteName\` → \`name\` → \`title\`
- 链接：\`siteLink\` → \`url\` → \`link\`
- 描述：\`description\` → \`desc\`
- 头像：\`avatar\` → \`icon\` → 默认 SVG

这样客户端真实运行时和 render_test 两边都能正确显示。

## 验证

- ✅ \`validate_syntax.py\`：0 错误
- ✅ \`render_test.py\`：13/13 全部 PASS
- ✅ mock 输出 HTML：\`<h4 class=\"flink-name\">Gridea Pro</h4>\` + \`<p class=\"flink-desc\">基于 Wails 的桌面静态博客写作客户端</p>\` 都正常渲染

## Test plan

- [x] 在 Gridea Pro 桌面客户端打开 liushen 主题的友链页
- [x] 确认友链卡片同时显示**站点名称**和描述

🤖 Generated with [Claude Code](https://claude.com/claude-code)