### PR TITLE
docs(readme): 主题画廊补全 14 个主题 + 新增预览图列

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,15 +8,26 @@
 
 ## 🎨 主题画廊
 
-> 画廊还很空，等你来填满 👇
-
 <!-- GALLERY:BEGIN -->
 
-| 主题 | 引擎 | 说明 |
-|---|---|---|
-| **bitcron-pro** | Jinja2 (Pongo2) | Bitcron 风格博客主题，支持博客/闪念/友链页面 |
-| **liushen** | Jinja2 (Pongo2) | 柳神（Butterfly 衍生）风格双栏粉蓝渐变主题，复刻自 willow-god/hexo-theme-liushen |
-| **jasmine** | Jinja2 (Pongo2) | Bootstrap 5 + Tabler Icons 三栏极简博客主题，复刻自 liaocp666/Jasmine（Typecho） |
+| 预览 | 主题 | 引擎 | 说明 |
+|---|---|---|---|
+| <a href="./themes/flavor-theme/"><img src="./themes/flavor-theme/assets/media/preview.png" width="240" alt="flavor 预览"></a> | [**flavor**](./themes/flavor-theme/) | Jinja2 (Pongo2) | 暗色编辑感主题，电影感 hero + 紧凑卡片 + Spectral 衬线，灵感来自现代 newsletter 平台 |
+| <a href="./themes/amore/"><img src="./themes/amore/assets/media/preview.png" width="240" alt="Amore 预览"></a> | [**amore**](./themes/amore/) | EJS | 极简博客主题，聚焦阅读体验，支持明/暗双主题、阅读进度、闪念热力图 |
+| <a href="./themes/amore-jinja2/"><img src="./themes/amore-jinja2/assets/media/preview.png" width="240" alt="Amore Jinja2 预览"></a> | [**amore-jinja2**](./themes/amore-jinja2/) | Jinja2 (Pongo2) | Amore 主题的 Jinja2 版，特性同 amore |
+| — | [**fly**](./themes/fly/) | EJS | 现代简洁的博客主题，响应式布局（EryouHao） |
+| <a href="./themes/inotes/"><img src="./themes/inotes/assets/media/preview.png" width="240" alt="iNotes 预览"></a> | [**inotes**](./themes/inotes/) | Go Templates | Notes 主题升级版（Eliauk） |
+| — | [**notes**](./themes/notes/) | EJS | 经典笔记风格主题，Gridea 社区老牌主题，简洁易读 |
+| — | [**simple**](./themes/simple/) | EJS | 极简风格主题，专注阅读体验（EryouHao） |
+| <a href="./themes/hello-friend/"><img src="./themes/hello-friend/assets/media/preview.png" width="240" alt="Hello Friend 预览"></a> | [**hello-friend**](./themes/hello-friend/) | Jinja2 (Pongo2) | Hugo `hello-friend-ng` 主题的 Jinja2 移植，Inter 字体 + Prism 高亮 + 深浅切换 |
+| <a href="./themes/paper/"><img src="./themes/paper/assets/media/preview.png" width="240" alt="Paper 预览"></a> | [**paper**](./themes/paper/) | Jinja2 (Pongo2) | Hugo `Paper` 主题的 Jinja2 移植，Tailwind CSS、排版优先、深浅模式 |
+| <a href="./themes/bitcron-pro/"><img src="./themes/bitcron-pro/assets/media/preview.png" width="240" alt="bitcron-pro 预览"></a> | [**bitcron-pro**](./themes/bitcron-pro/) | Jinja2 (Pongo2) | Bitcron 风格博客主题，支持博客/闪念/友链页面 |
+| <a href="./themes/gazette/"><img src="./themes/gazette/assets/media/preview.png" width="240" alt="Gazette 预览"></a> | [**gazette**](./themes/gazette/) | Jinja2 (Pongo2) | Editorial 编辑感主题，全局衬线 + 暖奶油底 + 桑红重点 + 发丝分割线 + drop cap |
+| <a href="./themes/nacre/"><img src="./themes/nacre/assets/media/preview.png" width="240" alt="Nacre 预览"></a> | [**nacre**](./themes/nacre/) | Jinja2 (Pongo2) | 温柔静谧的深色主题，如珍珠母在暗处生辉，支持 Swiper 头图与多内容面板 |
+| <a href="./themes/liushen/"><img src="./themes/liushen/assets/media/preview.png" width="240" alt="liushen 预览"></a> | [**liushen**](./themes/liushen/) | Jinja2 (Pongo2) | 柳神（Butterfly 衍生）风格双栏粉蓝渐变主题，复刻自 willow-god/hexo-theme-liushen |
+| <a href="./themes/jasmine/"><img src="./themes/jasmine/assets/media/preview.png" width="240" alt="Jasmine 预览"></a> | [**jasmine**](./themes/jasmine/) | Jinja2 (Pongo2) | Bootstrap 5 + Tabler Icons 三栏极简博客主题，复刻自 liaocp666/Jasmine（Typecho） |
+
+> 上方前 7 个为初始入库的种子主题（其中 `flavor` 为 Gridea Pro 官方旗舰），下方按入库顺序排列社区主题。
 
 <!-- GALLERY:END -->
 


### PR DESCRIPTION
## Summary

- 把 `themes/` 目录下所有已入库主题列入主题画廊（共 **14 个**），不再只展示最近三个。
- 表格新增「**预览**」列，直接嵌入各主题 `assets/media/preview.png` 缩略图（`width=240`），缩略图本身链接到主题目录方便点击进入。
- 排序：**第一批 7 个种子主题置顶**（`flavor` 为首），后续社区主题按 git 入库顺序排在下方；表格末尾加一行简短说明区分两组。
- 未跟踪的 `themes/memos/`、被 `.gitignore` 的 `hugo-paper-main` / `hugo-theme-hello-friend-ng-master` 上游源码目录均不进画廊。

## 主题排序

种子主题：`flavor` → `amore` → `amore-jinja2` → `fly` → `inotes` → `notes` → `simple`
社区主题：`hello-friend` → `paper` → `bitcron-pro` → `gazette` → `nacre` → `liushen` → `jasmine`

`fly` / `notes` / `simple` 仓库里目前没有 preview 图，那一格用 `—` 占位，后续补图直接替换即可。

## Test plan

- [ ] 在 GitHub 上预览渲染后的 README，确认 14 个主题都展示，缩略图正确加载
- [ ] 点击缩略图能跳到对应主题目录
- [ ] 占位行（fly / notes / simple）排版没崩
- [ ] 引擎列与各主题 `config.json` 中 `templateEngine` 字段一致

🤖 Generated with [Claude Code](https://claude.com/claude-code)