### PR TITLE
docs(readme): 主题画廊补 mango 行（PR #18 漏合修复）

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@
 | <a href="./themes/kehua/"><img src="./themes/kehua/assets/media/preview.png" width="240" alt="Kehua 预览"></a> | [**kehua**](./themes/kehua/) | Jinja2 (Pongo2) | 扁平卡片 + 双栏留白主题，朴素配色，不依赖 Bootstrap |
 | <a href="./themes/printer/"><img src="./themes/printer/assets/media/preview.png" width="240" alt="Printer 预览"></a> | [**printer**](./themes/printer/) | Jinja2 (Pongo2) | 打字机字体 + 文档风排版主题，复刻自 Ouxxxxxjoe/Printer-Typecho |
 | <a href="./themes/memos/"><img src="./themes/memos/assets/media/preview.png" width="240" alt="memos 预览"></a> | [**memos**](./themes/memos/) | Jinja2 (Pongo2) | Bootstrap 5 双栏博客主题，sticky 顶栏 + Offcanvas 汉堡 + 闪念页，复刻自 jkjoy/Typecho-Theme-Once |
+| <a href="./themes/mango/"><img src="./themes/mango/assets/media/preview.png" width="240" alt="Mango 预览"></a> | [**mango**](./themes/mango/) | Jinja2 (Pongo2) | 双栏明亮博客主题，推荐位轮播 + 多图九宫格卡片 + 闪念热力图，复刻自 jkjoy/Typecho-Theme-Mango |
 
 > 上方前 7 个为初始入库的种子主题（其中 `flavor` 为 Gridea Pro 官方旗舰），下方按入库顺序排列社区主题。
 


### PR DESCRIPTION
## Summary

收尾补漏。PR #18 合并时仅取了「补 6 个主题」的初版（cactus / initial / weibo / kehua / printer / memos），随后追加的 mango 行 commit 没赶上合并。但 mango 主题目录通过 PR #19 已经入库，所以现在状态是：`themes/mango/` 在 main 上，但 README GALLERY 缺它一行。

本 PR 一行修复，把 mango 也写进画廊。

## Diff

```diff
+| <a href="./themes/mango/"><img src="./themes/mango/assets/media/preview.png" width="240" alt="Mango 预览"></a> | [**mango**](./themes/mango/) | Jinja2 (Pongo2) | 双栏明亮博客主题，推荐位轮播 + 多图九宫格卡片 + 闪念热力图，复刻自 jkjoy/Typecho-Theme-Mango |
```

放在 memos 之后，与 PR #19 入库顺序一致。

## Test plan

- [x] `themes/mango/assets/media/preview.png` 已在 main（PR #19 提供，138KB）
- [x] 表格列数对齐
- [x] `<!-- GALLERY:BEGIN -->` / `<!-- GALLERY:END -->` 边界保持原样

🤖 Generated with [Claude Code](https://claude.com/claude-code)